### PR TITLE
set the width of u-details to 100%, to avoid min read and save button…

### DIFF
--- a/src/Scss/_articlecomponent.scss
+++ b/src/Scss/_articlecomponent.scss
@@ -42,6 +42,7 @@
       padding-left: 0.5rem;
 
       margin-bottom: 0.5rem;
+      width: 100%;
 
       .u-name,
       .time {


### PR DESCRIPTION
… collision with comments and reaction section. The size of u-details in article components depends on the space taken by title and tags, which makes u-details box small sometimes. Which causes the the save button and minute read to come closer to comment icon. So, please merge this request to fix this bug.